### PR TITLE
xargs warning for -n & -l used together

### DIFF
--- a/response.sh
+++ b/response.sh
@@ -14,4 +14,5 @@ fetch_resp() {
 
 
 export -f fetch_resp
-cat $1 | xargs -P 50 -n 1 -I {} bash -c "fetch_resp {}"
+## cat $1 | xargs -P 50 -n 1 -I {} bash -c "fetch_resp {}"
+cat $1 | xargs -P 50 -I {} bash -c "fetch_resp {}"


### PR DESCRIPTION
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value

The warning happen cz `-I` already shows the number of args which is 1 `{}`. So with `-n 1` looks like there are 2 option that shows how much the number of args.
Great works btw, thank you.